### PR TITLE
Compatibility changes for python3.

### DIFF
--- a/configcli/__init__.py
+++ b/configcli/__init__.py
@@ -13,9 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-from abc import ABCMeta, abstractmethod
 
+try:
+    from abc import ABC, abstractmethod
+except:
+    from abc import ABCMeta, abstractmethod
+    class ABC(object):
+        __metaclass__ = ABCMeta
 import argparse, copy
 
 from .utils import isDebug
@@ -23,11 +27,10 @@ from .utils.misc import processArgs
 from .version import __version__
 
 
-class ConfigCLI_SubCommand(object):
+class ConfigCLI_SubCommand(ABC):
     """
 
     """
-    __metaclass__ = ABCMeta
 
     def __init__(self, cmdObj, subcmd):
         self.command = cmdObj
@@ -61,11 +64,10 @@ class ConfigCLI_SubCommand(object):
     def complete(self, text, argsList):
         raise Exception("Function must be implemented.")
 
-class ConfigCLI_Command(object):
+class ConfigCLI_Command(ABC):
     """
 
     """
-    __metaclass__ = ABCMeta
 
     def __init__(self, ccli, cmd, desc):
         """
@@ -100,9 +102,9 @@ class ConfigCLI_Command(object):
             macro = configcli.getCommandObject('macro')
             nodeMacro = macro.getSubcommandObject('node')
             ...
-            
+
         """
-        if (name != None) and (self.subcommands.has_key(name)):
+        if (name != None) and (name in self.subcommands):
             return self.subcommands[name]
         else:
             return None
@@ -150,13 +152,13 @@ class ConfigCLI_Command(object):
         """
         splits = self._split_line(line.strip())
         if (len(splits) < 2 and text == '') or (len(splits) == 2 and text != ''):
-            completionOpts = copy.deepcopy(self.subcommands.keys())
+            completionOpts = copy.deepcopy(list(self.subcommands.keys()))
             completionOpts.append('-h')
             return [x for x in completionOpts if x.startswith(text)]
         else:
             splits.pop(0)
             return self._invoke_subcmd_complete(splits, text)
 
-from configcli import ConfigCli
+from .configcli import ConfigCli
 
 __all__ = [ "ConfigCli", "__version__" ]

--- a/configcli/__macro_main__.py
+++ b/configcli/__macro_main__.py
@@ -12,10 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import print_function
+
 
 import sys
-from configcli import ConfigCli as ConfigCli
+from .configcli import ConfigCli as ConfigCli
 
 def main():
     configcli = ConfigCli(shell=False)

--- a/configcli/__main__.py
+++ b/configcli/__main__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from configcli import ConfigCli as ConfigCli
+from .configcli import ConfigCli as ConfigCli
 import sys, argparse
 
 

--- a/configcli/baseimg/__init__.py
+++ b/configcli/baseimg/__init__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+
 from .. import ConfigCLI_Command
 
 from .version import BaseimageVersion

--- a/configcli/baseimg/version.py
+++ b/configcli/baseimg/version.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import print_function
+
 import os
 
 from .. import ConfigCLI_SubCommand

--- a/configcli/ccli/__init__.py
+++ b/configcli/ccli/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+
 from .. import ConfigCLI_Command
 
 from .version import CcliVersion

--- a/configcli/ccli/version.py
+++ b/configcli/ccli/version.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+
 from .. import ConfigCLI_SubCommand
 from ..constants import ConfigCLI_VERSION
 

--- a/configcli/config.py
+++ b/configcli/config.py
@@ -13,10 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+
 
 import os
-import ConfigParser
+try:
+    from configparser import ConfigParser, NoSectionError, NoOptionError
+except:
+    from ConfigParser import SafeConfigParser as ConfigParser, NoSectionError, NoOptionError
 
 from .constants import *
 
@@ -31,7 +34,7 @@ class CcliConfig(object):
     def __init__(self):
         """
         """
-        self.config = ConfigParser.SafeConfigParser(defaults={
+        self.config = ConfigParser(defaults={
             KEY_LOGDIR              : DEFAULT_LOG_DIR,
             KEY_PRIV_METDATA_FILE   : PRIV_CONFIG_METDATA_FILE,
             KEY_CONFIGMETA_FILE     : PUBLIC_CONFIG_METADATA_FILE,
@@ -58,7 +61,8 @@ class CcliConfig(object):
         """
         try:
             return self.config.get(section, key)
-        except ConfigParser.NoSectionError, ConfigParser.NoOptionError:
+        except NoSectionError as xxx_todo_changeme:
+            NoOptionError = xxx_todo_changeme
             return default
 
     def addOrUpdate(self, section, key, value):

--- a/configcli/configcli.py
+++ b/configcli/configcli.py
@@ -13,25 +13,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-from __future__ import with_statement
+
+
 
 import os, sys, cmd, pkgutil
 
 from . import ConfigCLI_Command
 
-from utils import isDebug
-from config import CcliConfig
-from utils.log import CcliLog
-from errors import ArgumentParseError, UnknownValueType
-from constants import ConfigCLI_VERSION
+from .utils import isDebug
+from .config import CcliConfig
+from .utils.log import CcliLog
+from .errors import ArgumentParseError, UnknownValueType
+from .constants import ConfigCLI_VERSION
 
-from ccli import Ccli
-from baseimg import Baseimage
-from namespace import Namespace
+from .ccli import Ccli
+from .baseimg import Baseimage
+from .namespace import Namespace
 
 ## macro depends on Namesapce so import it after it.
-from macro import Macro
+from .macro import Macro
+
+# py2 and py3 compatibility:
+if sys.version_info[0] == 3:
+    unicode = str
 
 # # FIXME! test this code
 # EXTENSIONS_PATH = '/opt/bluedata/configcli/extensions'
@@ -87,7 +91,7 @@ class ConfigCli(cmd.Cmd):
             roleId = namespace.getValue('node.role_id')
             distroId = namespace.getValue('node.distro_id')
         """
-        if (name != None) and (self.commands.has_key(name)):
+        if (name != None) and (name in self.commands):
             return self.commands[name]
         else:
             return None
@@ -219,7 +223,7 @@ class ConfigCli(cmd.Cmd):
             try:
                 return ','.join(result)
             except Exception:
-                return ','.join(result[0].keys())
+                return ','.join(list(result[0].keys()))
         elif isinstance(result, bool):
             return "true" if result else "false"
         elif isinstance(result, str) or isinstance(result, unicode):
@@ -238,7 +242,7 @@ class ConfigCli(cmd.Cmd):
     def completedefault(self, *ignored):
         (text, line, begidx, endidx) = ignored
         command = line.strip().split()[0]
-        if self.commands.has_key(command):
+        if command in self.commands:
             return self.commands[command].complete(text, line, begidx, endidx)
         else:
             return cmd.Cmd.completedefault(self, ignored)

--- a/configcli/constants.py
+++ b/configcli/constants.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from version import __version__ as VERSION
+from .version import __version__ as VERSION
 import os
 
 ConfigCLI_VERSION = VERSION

--- a/configcli/macro/__init__.py
+++ b/configcli/macro/__init__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+
 
 import json
 import argparse

--- a/configcli/macro/node.py
+++ b/configcli/macro/node.py
@@ -67,7 +67,7 @@ class MacroNode(ConfigCLI_SubCommand):
         """
         Calculate node index given a node_id
         """
-        all_node_id_keys = self.command.configmeta.searchForToken([u"nodegroups"], u"node_ids")
+        all_node_id_keys = self.command.configmeta.searchForToken(["nodegroups"], "node_ids")
 
         node_id_list = []
         for node_id_key in all_node_id_keys:
@@ -84,7 +84,7 @@ class MacroNode(ConfigCLI_SubCommand):
         """
         Return the node index of current node
         """
-        node_id = self.command.configmeta.getWithTokens([u"node", u"id"])
+        node_id = self.command.configmeta.getWithTokens(["node", "id"])
         return self._getNodeIndexFromId(node_id)
 
     def getNodeIndexFromFqdn(self, fqdn):
@@ -98,13 +98,13 @@ class MacroNode(ConfigCLI_SubCommand):
         """
         Return node id of current node
         """
-        return self.command.configmeta.getWithTokens([u"node", u"id"])
+        return self.command.configmeta.getWithTokens(["node", "id"])
 
     def getNodeIdFromFqdn(self, fqdn):
         """
         Return the node id of a given fqdn
         """
-        all_fqdn_keys = self.command.configmeta.searchForToken([u"nodegroups"], u"fqdn_mappings")
+        all_fqdn_keys = self.command.configmeta.searchForToken(["nodegroups"], "fqdn_mappings")
         for fqdn_key in all_fqdn_keys:
             fqdn_token_list = self.command.configmeta.searchForToken(fqdn_key, fqdn)
             if fqdn_token_list != []:

--- a/configcli/macro/nodegroup.py
+++ b/configcli/macro/nodegroup.py
@@ -64,14 +64,14 @@ class MacroNodegroup(ConfigCLI_SubCommand):
         """
         Get node FQDNs that belong to the same nodegroup as the current node.
         """
-        LocalNodeGrpId = self.command.configmeta.getWithTokens([u"node", u"nodegroup_id"])
+        LocalNodeGrpId = self.command.configmeta.getWithTokens(["node", "nodegroup_id"])
         return self.getNodegroupFqdns(LocalNodeGrpId)
 
     def getClusterFqdns(self):
         """
         Get node FQDNs in the cluster.
         """
-        NodeGroups = self.command.configmeta.getWithTokens([u"nodegroups"])
+        NodeGroups = self.command.configmeta.getWithTokens(["nodegroups"])
 
         fqdnList = []
         for ng in NodeGroups:
@@ -84,9 +84,9 @@ class MacroNodegroup(ConfigCLI_SubCommand):
         """
         Get node FQDNs that are part of the given nodegroup.
         """
-        matchedKeyTokenLists = self.command.configmeta.searchForToken([u"nodegroups",
+        matchedKeyTokenLists = self.command.configmeta.searchForToken(["nodegroups",
                                                                         str(nodeGroupId)],
-                                                                      u"fqdns")
+                                                                      "fqdns")
         if len(matchedKeyTokenLists) == 0:
             raise KeyError("No nodegroup %s found." % (nodeGroupId))
 
@@ -99,13 +99,13 @@ class MacroNodegroup(ConfigCLI_SubCommand):
             else:
                 dupslist.append(val)
 
-        return dict.fromkeys(dupslist).keys()
+        return list(dict.fromkeys(dupslist).keys())
 
     def getNumNodegroups(self):
         """
         Returns count of nodegroups in this cluster.
         """
-        return len(self.command.configmeta.getWithTokens([u"nodegroups"]))
+        return len(self.command.configmeta.getWithTokens(["nodegroups"]))
 
     def complete(self, text, argsList):
         return []

--- a/configcli/namespace/auth.py
+++ b/configcli/namespace/auth.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+
 from .. import ConfigCLI_SubCommand
 
 class NamespaceAuth(ConfigCLI_SubCommand):

--- a/configcli/namespace/cluster.py
+++ b/configcli/namespace/cluster.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+
 from .. import ConfigCLI_SubCommand
 
 class NamespaceCluster(ConfigCLI_SubCommand):

--- a/configcli/namespace/connections.py
+++ b/configcli/namespace/connections.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import print_function
+
 from .. import ConfigCLI_SubCommand
 
 class NamespaceConnections(ConfigCLI_SubCommand):

--- a/configcli/namespace/distros.py
+++ b/configcli/namespace/distros.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+
 from .. import ConfigCLI_SubCommand
 
 class NamespaceDistros(ConfigCLI_SubCommand):

--- a/configcli/namespace/node.py
+++ b/configcli/namespace/node.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+
 from .. import ConfigCLI_SubCommand
 
 class NamespaceNode(ConfigCLI_SubCommand):

--- a/configcli/namespace/platform.py
+++ b/configcli/namespace/platform.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+
 from .. import ConfigCLI_SubCommand
 
 class NamespacePlatform(ConfigCLI_SubCommand):

--- a/configcli/namespace/services.py
+++ b/configcli/namespace/services.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+
 from .. import ConfigCLI_SubCommand
 
 class NamespaceServices(ConfigCLI_SubCommand):

--- a/configcli/namespace/tenant.py
+++ b/configcli/namespace/tenant.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+
 from .. import ConfigCLI_SubCommand
 
 class NamespaceTenant(ConfigCLI_SubCommand):

--- a/configcli/namespace/version.py
+++ b/configcli/namespace/version.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+
 from .. import ConfigCLI_SubCommand
 
 class NamespaceVersion(ConfigCLI_SubCommand):

--- a/configcli/utils/__init__.py
+++ b/configcli/utils/__init__.py
@@ -12,8 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from __future__ import print_function
+
 from ..constants import ENV_ConfigCLI_DEBUG
 
 import os
@@ -24,13 +24,13 @@ def printKeyVal(key,val):
 
 def printDict(data, header=None, footer=None, indent=4):
     """
-    Print the 'data' based on it's instance type with appropriate indentation.
+    Print the 'data' based on its instance type with appropriate indentation.
     """
     if header != None:
         print(header)
 
     if isinstance(data, dict):
-        for key, value in data.iteritems():
+        for key, value in data.items():
             print(indent * ' ', key, ': ', end='')
             if isinstance(value, dict):
                 printDict(value, indent=indent+4)

--- a/configcli/utils/complete.py
+++ b/configcli/utils/complete.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+
 
 import os
 

--- a/configcli/utils/misc.py
+++ b/configcli/utils/misc.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+
 
 from ..errors import ArgumentParseError
 

--- a/install
+++ b/install
@@ -22,4 +22,5 @@ mkdir -p /var/log/guestconfig
 mkdir -p /opt/guestconfig
 chmod a+X /opt/guestconfig /var/log/guestconfig
 
-(cd ${THIS_DIR}; python setup.py install)
+PYTHON_CMD=$(command -v python3 || command -v python)
+(cd ${THIS_DIR}; ${PYTHON_CMD} setup.py install --prefix /usr)

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from distutils.core import setup
-from setuptools import find_packages
+from setuptools import setup, find_packages
 
 import configcli
 


### PR DESCRIPTION
Most of these changes come about after running the py2to3 script.
Then some further changes as necessary.
The dropping of `from __future__ import print_function` was done by py2to3 and is harmless except for the few files where it is necessary.
It was tempting to use `six` for the compatibility layer, but I didn't want to introduce additional dependencies (python-six isn't installed in bluedata/centos7.