### PR TITLE
BDP-2740: configcli 0.7 is broken in all KD pods

### DIFF
--- a/install
+++ b/install
@@ -23,4 +23,4 @@ mkdir -p /opt/guestconfig
 chmod a+X /opt/guestconfig /var/log/guestconfig
 
 PYTHON_CMD=$(command -v python3 || command -v python)
-(cd ${THIS_DIR}; ${PYTHON_CMD} setup.py install --prefix /usr)
+(cd ${THIS_DIR}; ${PYTHON_CMD} setup.py install --install-scripts /usr/bin)


### PR DESCRIPTION
For the previous py2 / py3 change, the install used:
```PYTHON_CMD=$(command -v python3 || command -v python)```

That worked on each of the base bluedata images, picking up python3 from CentOS8, where there is no default python.
Trouble is, this picks up python3 from a non-standard installation, e.g.
```
# ls -l /usr/bin/python3
lrwxrwxrwx. 1 root root 26 Oct 25 16:42 /usr/bin/python3 -> /opt/miniconda/bin/python3
```

We now insist on picking up python from /usr/bin and installing using --prefix /usr, since that is where KD is expecting to pick up the configcli script.