### PR TITLE
BDP-2740: configcli 0.7 is broken in all KD pods

### DIFF
--- a/install
+++ b/install
@@ -23,4 +23,4 @@ mkdir -p /opt/guestconfig
 chmod a+X /opt/guestconfig /var/log/guestconfig
 
 PYTHON_CMD=$(command -v python3 || command -v python)
-(cd ${THIS_DIR}; ${PYTHON_CMD} setup.py install --prefix /usr)
+(cd ${THIS_DIR}; ${PYTHON_CMD} setup.py install --install-scripts /usr/bin)


### PR DESCRIPTION
For the previous py2 / py3 change, the install used:

PYTHON_CMD=$(command -v python3 || command -v python)
(cd ${THIS_DIR}; ${PYTHON_CMD} setup.py install --prefix /usr)

That was to ensure the script got installed into /usr/bin/configcli  and also work around a CentOS8 bug.

That creates a misconfigured install if the python is not installed in /usr. E.g.
```
# ls -l /usr/bin/python3
lrwxrwxrwx. 1 root root 26 Oct 25 16:42 /usr/bin/python3 -> /opt/miniconda/bin/python3
```
Therefore, revert back to using the default prefix and just change the install-scripts directory.
