### PR TITLE
configcli install now just installs to the default python.

### DIFF
--- a/install
+++ b/install
@@ -22,5 +22,4 @@ mkdir -p /var/log/guestconfig
 mkdir -p /opt/guestconfig
 chmod a+X /opt/guestconfig /var/log/guestconfig
 
-PYTHON_CMD=$(command -v python3 || command -v python)
-(cd ${THIS_DIR}; ${PYTHON_CMD} setup.py install --install-scripts /usr/bin)
+(cd ${THIS_DIR}; python setup.py install --install-scripts /usr/bin)


### PR DESCRIPTION
Note: the bluedata/centos8 image needs to be updated to have a default 
python (it didn't before!). If a user's image installs another version of python, it must be 
made the default in order to have configcli available to it.