### PR TITLE
support installation to "user home"

### DIFF
--- a/install
+++ b/install
@@ -22,4 +22,15 @@ mkdir -p /var/log/guestconfig
 mkdir -p /opt/guestconfig
 chmod a+X /opt/guestconfig /var/log/guestconfig
 
-(cd ${THIS_DIR}; python setup.py install --install-scripts /usr/bin)
+if [[ "$1" == "--new" ]]
+then
+    scripthome=$(python -c 'import site; print(site.USER_BASE)')/bin
+    installdir=$(python -c 'import site; print(site.USER_SITE)')
+    mkdir -p "$installdir"
+    installarg="--user"
+else
+    scripthome="/usr/bin"
+    installarg=""
+fi
+
+(cd ${THIS_DIR}; python setup.py install "$installarg" --install-scripts="$scripthome")


### PR DESCRIPTION
This is part of a general setup-layout-changing exercise in KD to reduce the amount of data copied to the PV. In this case we don't want to be required to move all of /usr, or even just /usr/bin and /usr/lib, to the PV.

In practice, the "user home" where we install configcli will be the /usr/local directory, determined by KD setting the PYTHONUSERBASE env var on the container. Persisting /usr/local/bin and /usr/local/lib is vastly more lightweight than the old behavior.

Note that this is a selectable behavior -- rather than a new default behavior -- because it is up to the kdapp to opt in to this new behavior. There are enough changes involved here that the new layout can break an existing kdapp startscript that is not aware of it. Mostly because of hardcoded paths to the old scripts.

This will be part of a new configcli tag/release, so to be clear it won't affect older KD releases or (re)builds of older KD versions. (Although even if this code did get used in an older KD it would still work fine, because the "--new" argument would not be supplied.)